### PR TITLE
keyboard support, node remove/split actions

### DIFF
--- a/AlinasMods.sln
+++ b/AlinasMods.sln
@@ -5,18 +5,20 @@ VisualStudioVersion = 17.4.33122.133
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{452A23A6-81C8-49C6-A7EE-95FD9377F896}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGES.md = CHANGES.md
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Paths.user = Paths.user
+		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{1CF8EA97-D7B9-4AD9-B08B-2A2140F897D5}") = "AlinasMapMod", "AlinasMapMod\AlinasMapMod.csproj", "{5A3A18BA-6DB3-41B5-BD90-CCA58B8C83B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AlinasMapMod", "AlinasMapMod\AlinasMapMod.csproj", "{5A3A18BA-6DB3-41B5-BD90-CCA58B8C83B4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MapEditor", "MapEditor\MapEditor.csproj", "{D49B95EB-0F2B-43EB-817E-9226E8961E66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MapEditor", "MapEditor\MapEditor.csproj", "{D49B95EB-0F2B-43EB-817E-9226E8961E66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransformHandles", "TransformHandles\TransformHandles.csproj", "{65837A87-F496-4304-A2B0-15C38D8EC5D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransformHandles", "TransformHandles\TransformHandles.csproj", "{65837A87-F496-4304-A2B0-15C38D8EC5D1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AlinasUtils", "AlinasUtils\AlinasUtils.csproj", "{427DE3F5-4F3D-497E-909A-0E50AB372F61}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AlinasUtils", "AlinasUtils\AlinasUtils.csproj", "{427DE3F5-4F3D-497E-909A-0E50AB372F61}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/AlinasMods.sln.DotSettings
+++ b/AlinasMods.sln.DotSettings
@@ -1,0 +1,10 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ACCESSOR_OWNER_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INVOCABLE_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/TYPE_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/AlinasMods.sln.DotSettings
+++ b/AlinasMods.sln.DotSettings
@@ -7,4 +7,8 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INVOCABLE_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">NEXT_LINE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/TYPE_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
     - alt mode for simple rail: removing 'noce B' from (node A --- node B --- node C) will result in (node A --- node C)
 - added 'Copy rotation' and 'Paste rotation' actions to node editor
     - first one will store node rotation and second one will create ChangeTrackNode action that will apply that rotation  
+- added 'Copy elevation' and 'Paste elevation' actions to node editor
 
 issues:
 - when I quit to main menu with editor open and start new game editor is still active and also start throwing exception, because some game objects where destryoed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,30 @@
+2024/06/09
+- selected node chevron is rendered with magenta color
+- keyboard support for node editing
+    - numpad keys 4,5,6,7,8,9 correspons to ui move / rotate buttons
+    - numpad enter toggles between move / rotate operation
+    - numpad + and numpad - changes scale
+    - numpad * and numpad / changes scale delta
+    - numpad 0 resets scale to 0
+- refactored code that is editing node from UIMoveTool to NodeManager class
+- refactored UIMoveTool BuildWindow method
+- refactored StateTracker classes
+    - glost classes store info about deleted node/segment for undo/redo magic to work
+    - it will also not store those values in ctor, because they may change before Apply/Revert is called
+
+- added 'Split' action to node editor
+    - this will remove selected node and replace it with multiple nodes roughly at the same location with track segments connections from old node 'other' nodes
+- added 'Remove' action to node editor
+    - this will remove node and its segmetnts
+    - alt mode for simple rail: removing 'noce B' from (node A --- node B --- node C) will result in (node A --- node C)
+
+
+
+
+issues:
+- when I quit to main menu with editor open and start new game editor is still active and also start throwing exception, because some game objects where destryoed
+  - tryied to register OnMapDidUnload event but didnt removed editor correctly ...
+- when I close UIMoveTool im unable to open it again
+  - i 'fixed' that by not removing event handler in OnDeactivating
+- game sometimes do not redraw rails correctly ('Rebuild Track' usually fixes that)
+  - i think that rebuild is not calling something / its timing issue

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,11 +15,10 @@
 - added 'Split' action to node editor
     - this will remove selected node and replace it with multiple nodes roughly at the same location with track segments connections from old node 'other' nodes
 - added 'Remove' action to node editor
-    - this will remove node and its segmetnts
+    - this will remove node and its segments
     - alt mode for simple rail: removing 'noce B' from (node A --- node B --- node C) will result in (node A --- node C)
-
-
-
+- added 'Copy rotation' and 'Paste rotation' actions to node editor
+    - first one will store node rotation and second one will create ChangeTrackNode action that will apply that rotation  
 
 issues:
 - when I quit to main menu with editor open and start new game editor is still active and also start throwing exception, because some game objects where destryoed
@@ -28,3 +27,6 @@ issues:
   - i 'fixed' that by not removing event handler in OnDeactivating
 - game sometimes do not redraw rails correctly ('Rebuild Track' usually fixes that)
   - i think that rebuild is not calling something / its timing issue
+- any reason behind `end_of_line = lf` in .editorconfig?
+  - git can handle converting those quite nicely
+  - on windows is really annoing to deal with 'Incostintent Line Endings' dialog every time i open or edit file

--- a/MapEditor/EditorContext.cs
+++ b/MapEditor/EditorContext.cs
@@ -10,6 +10,9 @@ using UnityEngine.SceneManagement;
 
 namespace MapEditor
 {
+  using MapEditor.Managers;
+
+  // note: this one do not know if it wants to be singleton or static class ... (static class makes more sense to me)
   public class EditorContext
   {
     public static EditorContext Instance { get; private set; }
@@ -86,6 +89,12 @@ namespace MapEditor
     {
       SelectedNode = newNode;
       NodeSelectedChanged?.Invoke(newNode);
+
+      if (newNode == null) {
+        KeyboardManager.Deactivate();
+      } else {
+        KeyboardManager.Activate();
+      }
     }
   }
 }

--- a/MapEditor/EditorContext.cs
+++ b/MapEditor/EditorContext.cs
@@ -20,8 +20,8 @@ namespace MapEditor
 
     public ChangeManager ChangeManager { get; private set; } = new ChangeManager();
 
-    public TrackNode SelectedNode { get; set; }
-    public TrackSegment SelectedSegment { get; set; }
+    public TrackNode? SelectedNode { get; set; }
+    public TrackSegment? SelectedSegment { get; set; }
 
     public TrackNode HoveredNode { get; set; }
     public TrackSegment HoveredSegment { get; set; }

--- a/MapEditor/EditorMod.cs
+++ b/MapEditor/EditorMod.cs
@@ -40,6 +40,7 @@ namespace MapEditor
       var harmony = new Harmony("AlinaNova21.AlinasMapMod.Editor");
       harmony.PatchAll();
       Messenger.Default.Register(this, new Action<MapDidLoadEvent>(OnMapDidLoad));
+      Messenger.Default.Register(this, new Action<MapDidUnloadEvent>(OnMapDidUnload));
     }
 
     public override void OnDisable()
@@ -110,6 +111,13 @@ namespace MapEditor
         logger.Debug(e.Message);
         logger.Debug(e.StackTrace);
       }
+    }
+
+    private void OnMapDidUnload(MapDidUnloadEvent @event)
+    {
+      var editor = UnityEngine.Object.FindObjectOfType<Editor>(true);
+      editor.gameObject.SetActive(false);
+      EditorContext.Unload(); 
     }
 
     public void ToolPanelDidOpen(UIPanelBuilder builder)

--- a/MapEditor/Extensions/PatchEditor.cs
+++ b/MapEditor/Extensions/PatchEditor.cs
@@ -1,0 +1,16 @@
+namespace MapEditor.Extensions {
+  using StrangeCustoms.Tracks;
+  using Track;
+
+  public static class PatchEditorExtensions {
+
+    public static void AddOrUpdateNode(this PatchEditor patchEditor, TrackNode trackNode) {
+      patchEditor.AddOrUpdateNode(trackNode.id, trackNode.transform.localPosition, trackNode.transform.localEulerAngles, trackNode.flipSwitchStand);
+    }
+
+    public static void AddOrUpdateSegment(this PatchEditor patchEditor, TrackSegment trackSegment) {
+      patchEditor.AddOrUpdateSegment(trackSegment.id, trackSegment.a.id, trackSegment.b.id, trackSegment.priority, trackSegment.groupId, trackSegment.speedLimit, trackSegment.style, trackSegment.trackClass);
+    }
+
+  }
+}

--- a/MapEditor/Extensions/UIPanelBuilder.cs
+++ b/MapEditor/Extensions/UIPanelBuilder.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using HarmonyLib;
 using Serilog;
 using TMPro;
@@ -6,30 +8,70 @@ using UI.Builder;
 using UnityEngine;
 using UnityEngine.UI;
 
-namespace MapEditor.Extensions;
-public static class UIPanelBuilderExtensions
+namespace MapEditor.Extensions
 {
-  public static RectTransform AddIconButton(this UIPanelBuilder builder, Sprite icon, Action action)
+  public static class UIPanelBuilderExtensions
   {
-    var builderAssets = AccessTools.Field(typeof(UIPanelBuilder), "_assets").GetValue(builder) as UIBuilderAssets;
-    var container = AccessTools.Field(typeof(UIPanelBuilder), "_container").GetValue(builder) as RectTransform;
-    // var button = UnityEngine.Object.Instantiate(builderAssets.button, container, false);
-    var button = new GameObject("Button").AddComponent<Button>();
-    var rect = button.gameObject.AddComponent<RectTransform>();
-    button.transform.SetParent(container, false);
-    button.onClick.AddListener(new UnityEngine.Events.UnityAction(action.Invoke));
-    foreach (var c in button.GetComponents<Component>())
+
+    public static RectTransform AddIconButton(this UIPanelBuilder builder, Sprite icon, Action action)
     {
-      Log.Debug("Component: {0}", c.GetType().Name);
+      var builderAssets = AccessTools.Field(typeof(UIPanelBuilder), "_assets").GetValue(builder) as UIBuilderAssets;
+      var container = AccessTools.Field(typeof(UIPanelBuilder), "_container").GetValue(builder) as RectTransform;
+      // var button = UnityEngine.Object.Instantiate(builderAssets.button, container, false);
+      var button = new GameObject("Button").AddComponent<Button>();
+      var rect = button.gameObject.AddComponent<RectTransform>();
+      button.transform.SetParent(container, false);
+      button.onClick.AddListener(action.Invoke);
+      foreach (var c in button.GetComponents<Component>())
+      {
+        Log.Debug("Component: {0}", c.GetType().Name);
+      }
+
+      var img = button.gameObject.AddComponent<Image>();
+      img.sprite = icon;
+      img.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 48);
+      img.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 48);
+      rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 48);
+      rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 48);
+      rect.Width(48);
+      rect.Height(48);
+      return rect;
     }
-    var img = button.gameObject.AddComponent<Image>();
-    img.sprite = icon;
-    img.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 48);
-    img.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 48);
-    rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 48);
-    rect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 48);
-    rect.Width(48);
-    rect.Height(48);
-    return rect;
+
+    public static RectTransform AddPopupMenu(this UIPanelBuilder builder, params PopupMenuItem[] items)
+    {
+      List<string> values = ["More ...", .. items.Select(o => o.DisplayName)];
+
+      TMP_Dropdown dd = null!;
+      var rect = builder.AddDropdown(values, 0, o =>
+      {
+        if (o == 0)
+        {
+          return;
+        }
+
+        items[o - 1].OnSelected();
+        dd.value = 0;
+      });
+      rect.FlexibleWidth();
+      dd = rect.GetComponent<TMP_Dropdown>();
+      dd.MultiSelect = false;
+      return rect;
+    }
+
+  }
+
+  public class PopupMenuItem
+  {
+
+    public PopupMenuItem(string displayName, Action onSelected)
+    {
+      DisplayName = displayName;
+      OnSelected = onSelected;
+    }
+
+    public string DisplayName { get; set; }
+    public Action OnSelected { get; set; }
+
   }
 }

--- a/MapEditor/Extensions/Vector3.cs
+++ b/MapEditor/Extensions/Vector3.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace MapEditor.Extensions
+{
+  public static class Vector3Extensions
+  {
+
+    public static Vector3 Clone(this Vector3 vector)
+    {
+      return new Vector3(vector.x, vector.y, vector.z);
+    }
+
+
+  }
+}

--- a/MapEditor/Managers/KeyboardManager.cs
+++ b/MapEditor/Managers/KeyboardManager.cs
@@ -55,7 +55,7 @@ namespace MapEditor.Managers {
         if (Rotate) {
           NodeManager.Rotate(Vector3.back);
         } else {
-          NodeManager.Move(Direction.up);
+          NodeManager.Move(Direction.down);
         }
       }
 
@@ -71,7 +71,7 @@ namespace MapEditor.Managers {
         if (Rotate) {
           NodeManager.Rotate(Vector3.forward);
         } else {
-          NodeManager.Move(Direction.down);
+          NodeManager.Move(Direction.up);
         }
       }
 

--- a/MapEditor/Managers/KeyboardManager.cs
+++ b/MapEditor/Managers/KeyboardManager.cs
@@ -1,0 +1,100 @@
+namespace MapEditor.Managers {
+  using JetBrains.Annotations;
+  using UnityEngine;
+
+  public sealed class KeyboardManager : MonoBehaviour {
+
+    private static GameObject? _gameObject;
+
+    public static void Activate() {
+      if (_gameObject == null) {
+        _gameObject = new GameObject("KeyboardManager");
+        _gameObject.AddComponent<KeyboardManager>();
+      }
+
+      _gameObject.SetActive(true);
+    }
+
+    public static void Deactivate() {
+      _gameObject!.SetActive(false);
+    }
+
+    public static bool Rotate { get; private set; }
+
+    [UsedImplicitly]
+    public void Update() {
+      if (Input.GetKeyDown(KeyCode.KeypadEnter)) {
+        Rotate = !Rotate;
+      }
+
+      if (Input.GetKeyDown(KeyCode.Keypad4)) {
+        if (Rotate) {
+          NodeManager.Rotate(Vector3.down);
+        } else {
+          NodeManager.Move(Direction.left);
+        }
+      }
+
+      if (Input.GetKeyDown(KeyCode.Keypad5)) {
+        if (Rotate) {
+          NodeManager.Rotate(Vector3.left);
+        } else {
+          NodeManager.Move(Direction.backward);
+        }
+      }
+
+      if (Input.GetKeyDown(KeyCode.Keypad6)) {
+        if (Rotate) {
+          NodeManager.Rotate(Vector3.up);
+        } else {
+          NodeManager.Move(Direction.right);
+        }
+      }
+
+      if (Input.GetKeyDown(KeyCode.Keypad7)) {
+        if (Rotate) {
+          NodeManager.Rotate(Vector3.back);
+        } else {
+          NodeManager.Move(Direction.up);
+        }
+      }
+
+      if (Input.GetKeyDown(KeyCode.Keypad8)) {
+        if (Rotate) {
+          NodeManager.Rotate(Vector3.right);
+        } else {
+          NodeManager.Move(Direction.forward);
+        }
+      }
+
+      if (Input.GetKeyDown(KeyCode.Keypad9)) {
+        if (Rotate) {
+          NodeManager.Rotate(Vector3.forward);
+        } else {
+          NodeManager.Move(Direction.down);
+        }
+      }
+
+      if (Input.GetKeyDown(KeyCode.KeypadPlus)) {
+        NodeManager.IncrementScaling();
+      }
+
+      if (Input.GetKeyDown(KeyCode.KeypadMinus)) {
+        NodeManager.DecrementScaling();
+      }
+
+      if (Input.GetKeyDown(KeyCode.KeypadMultiply)) {
+        NodeManager.MultiplyScalingDelta();
+      }
+
+      if (Input.GetKeyDown(KeyCode.KeypadDivide)) {
+        NodeManager.DivideScalingDelta();
+      }
+
+      if (Input.GetKeyDown(KeyCode.Keypad0)) {
+        NodeManager.ResetScaling();
+      }
+    }
+
+  }
+}

--- a/MapEditor/Managers/NodeManager.cs
+++ b/MapEditor/Managers/NodeManager.cs
@@ -221,6 +221,43 @@ namespace MapEditor.Managers
       Rebuild();
     }
 
+   
+    #region Rotation
+
+    private static Vector3 _savedRotation = Vector3.forward;
+
+    public static void CopyNodeRotation() {
+      var node = Context.SelectedNode;
+      _savedRotation = node.transform.localEulerAngles;
+    }
+
+    public static void PasteNodeRotation() {
+      var node = Context.SelectedNode;
+      Context.ChangeManager.AddChange(new ChangeTrackNode(node).Rotate(_savedRotation));
+
+      Rebuild();
+    }
+
+    #endregion
+
+    #region Elevation
+
+    private static float _savedElevation = 0;
+
+    public static void CopyNodeElevation() {
+      var node = Context.SelectedNode;
+      _savedElevation = node.transform.localPosition.y;
+    }
+
+    public static void PasteNodeElevation() {
+      var node = Context.SelectedNode;
+      Context.ChangeManager.AddChange(new ChangeTrackNode(node).Move(y: _savedElevation));
+
+      Rebuild();
+    }
+
+    #endregion
+
     private static void Rebuild()
     {
       // not sure why this is not working, but calling same method from 'Rebuild Track' button works ...
@@ -228,21 +265,6 @@ namespace MapEditor.Managers
       TrackObjectManager.Instance.Rebuild();
     }
 
-    private static Vector3 _savedRotation = Vector3.forward;
-
-    public static void CopyNodeRotation()
-    {
-      var node = Context.SelectedNode;
-      _savedRotation = node.transform.localEulerAngles;
-    }
-
-    public static void PasteNodeRotation()
-    {
-      var node = Context.SelectedNode;
-      Context.ChangeManager.AddChange(new ChangeTrackNode(node).Rotate(_savedRotation));
-
-      Rebuild();
-    }
 
   }
 }

--- a/MapEditor/Managers/NodeManager.cs
+++ b/MapEditor/Managers/NodeManager.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using MapEditor.StateTracker;
+using MapEditor.StateTracker.Node;
+using MapEditor.StateTracker.Segment;
+using MapEditor.Tools;
+using Track;
+using UI.Common;
+using UnityEngine;
+
+namespace MapEditor.Managers
+{
+  public static class NodeManager
+  {
+
+    private static EditorContext Context => EditorContext.Instance;
+
+    public static void Move(Direction direction)
+    {
+      var node = Context.SelectedNode;
+      if (node == null)
+      {
+        return;
+      }
+
+      var vector =
+        direction switch
+        {
+          Direction.up       => node.transform.up * Scaling,
+          Direction.down     => node.transform.up * -Scaling,
+          Direction.left     => node.transform.right * -Scaling,
+          Direction.right    => node.transform.right * Scaling,
+          Direction.forward  => node.transform.forward * Scaling,
+          Direction.backward => node.transform.forward * -Scaling,
+          _                  => throw new ArgumentOutOfRangeException(nameof(direction), direction, null)
+        };
+
+      Context.ChangeManager.AddChange(new ChangeTrackNode(node, node.transform.localPosition + vector, node.transform.localEulerAngles, node.flipSwitchStand));
+    }
+
+    public static void Rotate(Vector3 offset)
+    {
+      var node = Context.SelectedNode;
+      if (node == null)
+      {
+        return;
+      }
+
+      Context.ChangeManager.AddChange(new ChangeTrackNode(node, node.transform.localPosition, node.transform.localEulerAngles + offset * Scaling, node.flipSwitchStand));
+    }
+
+    public static void FlipSwitchStand()
+    {
+      var node = Context.SelectedNode;
+      if (node == null)
+      {
+        return;
+      }
+
+      Context.ChangeManager.AddChange(new ChangeTrackNode(node, node.transform.localPosition, node.transform.localEulerAngles, !node.flipSwitchStand));
+    }
+
+    #region Scaling
+
+    public static float Scaling { get; private set; } = 1.0f;
+    public static float ScalingDelta { get; private set; } = 1.0f;
+
+    public static void IncrementScaling()
+    {
+      Scaling += ScalingDelta;
+    }
+
+    public static void ResetScaling()
+    {
+      Scaling = 0;
+    }
+
+    public static void DecrementScaling()
+    {
+      Scaling -= ScalingDelta;
+    }
+
+    public static void MultiplyScalingDelta()
+    {
+      ScalingDelta *= 10;
+    }
+
+    public static void DivideScalingDelta()
+    {
+      if (ScalingDelta > 0.01f)
+      {
+        ScalingDelta /= 10;
+      }
+    }
+
+    #endregion
+
+    public static void AddNode()
+    {
+      var node = Context.SelectedNode;
+      var nid = Context.TrackNodeIdGenerator.Next();
+      var sid = Context.TrackSegmentIdGenerator.Next();
+      Context.ChangeManager.AddChange(new CompoundChange(
+        new CreateTrackNode(nid, node.transform.localPosition + node.transform.forward * Scaling, node.transform.localEulerAngles),
+        new CreateTrackSegment(sid, node.id, nid)
+      ));
+      var newNode = Graph.Shared.GetNode(nid);
+      Context.SelectNode(newNode);
+
+      Rebuild();
+    }
+
+    public static void ConnectNodes(string previousNodeId)
+    {
+      var sid = Context.TrackSegmentIdGenerator.Next();
+      var segmentCreated = new CreateTrackSegment(sid, previousNodeId, Context.SelectedNode.id);
+      Context.ChangeManager.AddChange(segmentCreated);
+
+      Rebuild();
+    }
+
+    public static void SplitNode()
+    {
+      // simple track node split:
+      // NODE_A --- NODE --- NODE_B
+      // result:
+      // NODE_A --- NEW_NODE_1
+      //            NEW_NODE_2 --- NODE_B
+
+      // switch node split:
+      // NODE_A ---\
+      //            >- NODE --- NODE_C
+      // NODE_B ---/
+      // result:
+      // NODE_A --- NEW_NODE_1
+      // NODE_B --- NEW_NODE_2
+      //            NEW_NODE_3 --- NODE_C
+      var node = Context.SelectedNode;
+      Context.SelectNode(null);
+
+      var actions = new List<IUndoable>();
+
+      var segments = Graph.Shared.SegmentsAffectedByNodes(new HashSet<TrackNode> { node });
+      foreach (var trackSegment in segments)
+      {
+        actions.Add(new DeleteTrackSegment(trackSegment));
+      }
+
+      actions.Add(new DeleteTrackNode(node));
+
+      foreach (var trackSegment in segments)
+      {
+        var other = trackSegment.GetOtherNode(node);
+
+        // move new node in direction of 'other' node (result should be then nodes not on top of each other with buffer stops on each end)
+        var offset = (other.transform.localPosition - node.transform.localPosition).normalized * 1.5f;
+
+        var nid = Context.TrackNodeIdGenerator.Next();
+        var sid = Context.TrackSegmentIdGenerator.Next();
+        actions.Add(new CreateTrackNode(nid, node.transform.localPosition + offset, node.transform.localEulerAngles));
+        actions.Add(new CreateTrackSegment(sid, other.id, nid));
+      }
+
+      Context.ChangeManager.AddChange(new CompoundChange(actions));
+
+      Rebuild();
+    }
+
+    public static void RemoveNode(bool altMode)
+    {
+      // end track node remove:
+      // NODE_A --- NODE
+      // result
+      // NODE_A
+
+      // simple track node remove:
+      // NODE_A --- NODE --- NODE_B
+      // result:
+      // NODE_A     NODE_B
+      // result (alt):
+      // NODE_A --- NODE_B
+
+      // switch track node remove:
+      // switch node split:
+      // NODE_A ---\
+      //            >- NODE --- NODE_C
+      // NODE_B ---/
+      // result:
+      // NODE_A     
+      //               NODE_C
+      // NODE_B 
+
+      var node = Context.SelectedNode;
+      Context.SelectNode(null);
+
+      var actions = new List<IUndoable>();
+
+      var segments = Graph.Shared.SegmentsAffectedByNodes(new HashSet<TrackNode> { node });
+
+      foreach (var trackSegment in segments)
+      {
+        actions.Add(new DeleteTrackSegment(trackSegment));
+      }
+
+      actions.Add(new DeleteTrackNode(node));
+
+      if (segments.Count == 2 && altMode)
+      {
+        var firstSegment = segments.First();
+        var firstNode = firstSegment.GetOtherNode(node);
+        var lastNode = segments.Last().GetOtherNode(node);
+
+        var sid = Context.TrackSegmentIdGenerator.Next();
+        actions.Add(new CreateTrackSegment(sid, firstNode.id, lastNode.id, firstSegment.priority, firstSegment.speedLimit, firstSegment.groupId, firstSegment.style, firstSegment.trackClass));
+      }
+
+      Context.ChangeManager.AddChange(new CompoundChange(actions));
+
+      Rebuild();
+    }
+
+    private static void Rebuild()
+    {
+      // not sure why this is not working, but calling same method from 'Rebuild Track' button works ...
+      Graph.Shared.RebuildCollections();
+      TrackObjectManager.Instance.Rebuild();
+    }
+
+  }
+}
+
+public enum Direction
+{
+
+  up,
+  down,
+  left,
+  right,
+  forward,
+  backward
+
+}

--- a/MapEditor/MapEditor.csproj
+++ b/MapEditor/MapEditor.csproj
@@ -5,6 +5,7 @@
     <MinorVersion>0</MinorVersion>
     <IsMod>true</IsMod>
     <PackageMod>enable</PackageMod>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="*.json" CopyToOutputDirectory="Always" />

--- a/MapEditor/StateTracker/CompoundChange.cs
+++ b/MapEditor/StateTracker/CompoundChange.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 
 namespace MapEditor.StateTracker
@@ -9,6 +10,11 @@ namespace MapEditor.StateTracker
         public CompoundChange(params IUndoable[] changes)
         {
             _changes = changes;
+        }
+
+        public CompoundChange(IEnumerable<IUndoable> changes)
+          : this(changes.ToArray())
+        {
         }
 
         public void Apply()

--- a/MapEditor/StateTracker/Node/ChangeTrackNode.cs
+++ b/MapEditor/StateTracker/Node/ChangeTrackNode.cs
@@ -33,6 +33,17 @@ namespace MapEditor.StateTracker.Node
       return this;
     }
 
+    public ChangeTrackNode Move(float? x = null, float? y = null, float? z = null)
+    {
+      if (!_isEditable)
+      {
+        throw new InvalidOperationException();
+      }
+
+      _new._position = new Vector3(x ?? _new._position.x, y ?? _new._position.y, z ?? _new._position.z);
+      return this;
+    }
+
     public ChangeTrackNode Rotate(Vector3 newRotation)
     {
       if (!_isEditable)

--- a/MapEditor/StateTracker/Node/ChangeTrackNode.cs
+++ b/MapEditor/StateTracker/Node/ChangeTrackNode.cs
@@ -1,0 +1,32 @@
+namespace MapEditor.StateTracker.Node {
+  using JetBrains.Annotations;
+  using MapEditor.Extensions;
+  using Track;
+  using UnityEngine;
+
+  public sealed class ChangeTrackNode : IUndoable {
+
+    private readonly TrackNode _node;
+    private readonly TrackNodeGhost _old;
+    private readonly TrackNodeGhost _new;
+
+    public ChangeTrackNode(TrackNode node, Vector3 newPosition, Vector3 newRotation, bool flipSwitchStand) {
+      _node = node;
+      _old = new TrackNodeGhost(node.id!);
+      _new = new TrackNodeGhost(node.id, newPosition, newRotation, flipSwitchStand);
+    }
+
+    public void Apply() {
+      _new.UpdateNode(_node);
+      EditorContext.Instance.PatchEditor.AddOrUpdateNode(_node);
+      Graph.Shared.OnNodeDidChange(_node);
+    }
+
+    public void Revert() {
+      _old.UpdateNode(_node);
+      EditorContext.Instance.PatchEditor.AddOrUpdateNode(_node);
+      Graph.Shared.OnNodeDidChange(_node);
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Node/CreateTrackNode.cs
+++ b/MapEditor/StateTracker/Node/CreateTrackNode.cs
@@ -1,0 +1,28 @@
+namespace MapEditor.StateTracker.Node {
+  using JetBrains.Annotations;
+  using UnityEngine;
+
+  public sealed class CreateTrackNode : IUndoable {
+
+    private readonly string _id;
+    private readonly TrackNodeGhost _ghost;
+
+    public CreateTrackNode(string id, Vector3 position, Vector3 rotation, bool flipSwitchStand = false) {
+      _id = id;
+      _ghost = new TrackNodeGhost(id, position, rotation, flipSwitchStand);
+    }
+
+    public void Apply() {
+      _ghost.CreateNode();
+    }
+
+    public void Revert() {
+      _ghost.DestroyNode();
+    }
+
+    public override string ToString() {
+      return "CreateTrackNode: " + _id;
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Node/CreateTrackNode.cs
+++ b/MapEditor/StateTracker/Node/CreateTrackNode.cs
@@ -1,26 +1,31 @@
-namespace MapEditor.StateTracker.Node {
-  using JetBrains.Annotations;
-  using UnityEngine;
+using UnityEngine;
 
-  public sealed class CreateTrackNode : IUndoable {
+namespace MapEditor.StateTracker.Node
+{
+  public sealed class CreateTrackNode : IUndoable
+  {
 
     private readonly string _id;
     private readonly TrackNodeGhost _ghost;
 
-    public CreateTrackNode(string id, Vector3 position, Vector3 rotation, bool flipSwitchStand = false) {
+    public CreateTrackNode(string id, Vector3 position, Vector3 rotation, bool flipSwitchStand = false)
+    {
       _id = id;
       _ghost = new TrackNodeGhost(id, position, rotation, flipSwitchStand);
     }
 
-    public void Apply() {
+    public void Apply()
+    {
       _ghost.CreateNode();
     }
 
-    public void Revert() {
+    public void Revert()
+    {
       _ghost.DestroyNode();
     }
 
-    public override string ToString() {
+    public override string ToString()
+    {
       return "CreateTrackNode: " + _id;
     }
 

--- a/MapEditor/StateTracker/Node/DeleteTrackNode.cs
+++ b/MapEditor/StateTracker/Node/DeleteTrackNode.cs
@@ -1,0 +1,28 @@
+namespace MapEditor.StateTracker.Node {
+  using JetBrains.Annotations;
+  using Track;
+
+  public sealed class DeleteTrackNode : IUndoable {
+
+    private readonly string _id;
+    private TrackNodeGhost _ghost;
+
+    public DeleteTrackNode(TrackNode trackNode) {
+      _id = trackNode.id!;
+    }
+
+    public void Apply() {
+      _ghost = new TrackNodeGhost(_id);
+      _ghost.DestroyNode();
+    }
+
+    public void Revert() {
+      _ghost!.CreateNode();
+    }
+
+    public override string ToString() {
+      return "DeleteTrackNode: " + _id;
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Node/DeleteTrackNode.cs
+++ b/MapEditor/StateTracker/Node/DeleteTrackNode.cs
@@ -1,26 +1,31 @@
-namespace MapEditor.StateTracker.Node {
-  using JetBrains.Annotations;
-  using Track;
+using Track;
 
-  public sealed class DeleteTrackNode : IUndoable {
+namespace MapEditor.StateTracker.Node
+{
+  public sealed class DeleteTrackNode : IUndoable
+  {
 
     private readonly string _id;
     private TrackNodeGhost _ghost;
 
-    public DeleteTrackNode(TrackNode trackNode) {
+    public DeleteTrackNode(TrackNode trackNode)
+    {
       _id = trackNode.id!;
     }
 
-    public void Apply() {
+    public void Apply()
+    {
       _ghost = new TrackNodeGhost(_id);
       _ghost.DestroyNode();
     }
 
-    public void Revert() {
+    public void Revert()
+    {
       _ghost!.CreateNode();
     }
 
-    public override string ToString() {
+    public override string ToString()
+    {
       return "DeleteTrackNode: " + _id;
     }
 

--- a/MapEditor/StateTracker/Node/TrackNodeGhost.cs
+++ b/MapEditor/StateTracker/Node/TrackNodeGhost.cs
@@ -1,41 +1,47 @@
-namespace MapEditor.StateTracker.Node {
-  using JetBrains.Annotations;
-  using MapEditor.Extensions;
-  using Track;
-  using UnityEngine;
+using MapEditor.Extensions;
+using Track;
+using UnityEngine;
 
-  public sealed class TrackNodeGhost {
+namespace MapEditor.StateTracker.Node
+{
+  public sealed class TrackNodeGhost
+  {
 
     private readonly string _id;
 
-    private Vector3 _position;
-    private Vector3 _rotation;
-    private bool _flipSwitchStand;
+    internal Vector3 _position;
+    internal Vector3 _rotation;
+    internal bool _flipSwitchStand;
 
-    public TrackNodeGhost(string id) {
+    public TrackNodeGhost(string id)
+    {
       _id = id;
     }
 
     public TrackNodeGhost(string id, Vector3 position, Vector3 rotation, bool flipSwitchStand)
-      : this(id) {
+      : this(id)
+    {
       _position = position;
       _rotation = rotation;
       _flipSwitchStand = flipSwitchStand;
     }
 
-    public void UpdateGhost(TrackNode node) {
+    public void UpdateGhost(TrackNode node)
+    {
       _position = node.transform.localPosition;
       _rotation = node.transform.localEulerAngles;
       _flipSwitchStand = node.flipSwitchStand;
     }
 
-    public void UpdateNode(TrackNode node) {
+    public void UpdateNode(TrackNode node)
+    {
       node.transform.localPosition = _position;
       node.transform.localEulerAngles = _rotation;
       node.flipSwitchStand = _flipSwitchStand;
     }
 
-    public void CreateNode() {
+    public void CreateNode()
+    {
       var node = new GameObject($"Node {_id}").AddComponent<TrackNode>();
       node.id = _id;
       node.transform.SetParent(Graph.Shared.transform);
@@ -44,7 +50,8 @@ namespace MapEditor.StateTracker.Node {
       EditorContext.Instance.PatchEditor.AddOrUpdateNode(node);
     }
 
-    public void DestroyNode() {
+    public void DestroyNode()
+    {
       var node = Graph.Shared.GetNode(_id);
       UpdateGhost(node);
       Object.Destroy(node.gameObject);

--- a/MapEditor/StateTracker/Node/TrackNodeGhost.cs
+++ b/MapEditor/StateTracker/Node/TrackNodeGhost.cs
@@ -1,0 +1,56 @@
+namespace MapEditor.StateTracker.Node {
+  using JetBrains.Annotations;
+  using MapEditor.Extensions;
+  using Track;
+  using UnityEngine;
+
+  public sealed class TrackNodeGhost {
+
+    private readonly string _id;
+
+    private Vector3 _position;
+    private Vector3 _rotation;
+    private bool _flipSwitchStand;
+
+    public TrackNodeGhost(string id) {
+      _id = id;
+    }
+
+    public TrackNodeGhost(string id, Vector3 position, Vector3 rotation, bool flipSwitchStand)
+      : this(id) {
+      _position = position;
+      _rotation = rotation;
+      _flipSwitchStand = flipSwitchStand;
+    }
+
+    public void UpdateGhost(TrackNode node) {
+      _position = node.transform.localPosition;
+      _rotation = node.transform.localEulerAngles;
+      _flipSwitchStand = node.flipSwitchStand;
+    }
+
+    public void UpdateNode(TrackNode node) {
+      node.transform.localPosition = _position;
+      node.transform.localEulerAngles = _rotation;
+      node.flipSwitchStand = _flipSwitchStand;
+    }
+
+    public void CreateNode() {
+      var node = new GameObject($"Node {_id}").AddComponent<TrackNode>();
+      node.id = _id;
+      node.transform.SetParent(Graph.Shared.transform);
+      UpdateNode(node);
+      Graph.Shared.AddNode(node);
+      EditorContext.Instance.PatchEditor.AddOrUpdateNode(node);
+    }
+
+    public void DestroyNode() {
+      var node = Graph.Shared.GetNode(_id);
+      UpdateGhost(node);
+      Object.Destroy(node.gameObject);
+      Graph.Shared.RebuildCollections();
+      EditorContext.Instance.PatchEditor.RemoveNode(_id);
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Segment/ChangeTrackSegment.cs
+++ b/MapEditor/StateTracker/Segment/ChangeTrackSegment.cs
@@ -1,0 +1,103 @@
+using System;
+using MapEditor.Extensions;
+using Track;
+
+namespace MapEditor.StateTracker.Segment
+{
+  public sealed class ChangeTrackSegment : IUndoable
+  {
+
+    private readonly TrackSegment _segment;
+    private readonly TrackSegmentGhost _old;
+    private readonly TrackSegmentGhost _new;
+    private bool _isEditable;
+
+    public ChangeTrackSegment(TrackSegment segment)
+    {
+      _segment = segment;
+      _old = new TrackSegmentGhost(segment.id!);
+      _new = new TrackSegmentGhost(segment.id, segment.a.id, segment.b.id);
+    }
+
+    public ChangeTrackSegment Priority(int priority)
+    {
+      if (!_isEditable)
+      {
+        throw new InvalidOperationException();
+      }
+
+      _new._priority = priority;
+      return this;
+    }
+
+    public ChangeTrackSegment SpeedLimit(int speedLimit)
+    {
+      if (!_isEditable)
+      {
+        throw new InvalidOperationException();
+      }
+
+      _new._speedLimit = speedLimit;
+      return this;
+    }
+
+    public ChangeTrackSegment GroupId(string GroupId)
+    {
+      if (!_isEditable)
+      {
+        throw new InvalidOperationException();
+      }
+
+      _new._groupId = GroupId;
+      return this;
+    }
+
+    public ChangeTrackSegment Style(TrackSegment.Style style)
+    {
+      if (!_isEditable)
+      {
+        throw new InvalidOperationException();
+      }
+
+      _new._style = style;
+      return this;
+    }
+
+    public ChangeTrackSegment TrackClass(TrackClass trackClass)
+    {
+      if (!_isEditable)
+      {
+        throw new InvalidOperationException();
+      }
+
+      _new._trackClass = trackClass;
+      return this;
+    }
+
+    public void Apply()
+    {
+      _isEditable = false;
+      _old.UpdateGhost(_segment);
+      _new.UpdateSegment(_segment);
+      EditorContext.Instance.PatchEditor.AddOrUpdateSegment(_segment);
+    }
+
+    public void Revert()
+    {
+      _old.UpdateSegment(_segment);
+      EditorContext.Instance.PatchEditor.AddOrUpdateSegment(_segment);
+    }
+
+    public ChangeTrackSegment SetGroupId(string value)
+    {
+      _new._groupId = value;
+      return this;
+    }
+
+    public override string ToString()
+    {
+      return "ChangeTrackSegment: " + _segment.id;
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Segment/CreateTrackSegment.cs
+++ b/MapEditor/StateTracker/Segment/CreateTrackSegment.cs
@@ -1,26 +1,31 @@
-namespace MapEditor.StateTracker.Segment {
-  using JetBrains.Annotations;
-  using Track;
+using Track;
 
-  public sealed class CreateTrackSegment : IUndoable {
+namespace MapEditor.StateTracker.Segment
+{
+  public sealed class CreateTrackSegment : IUndoable
+  {
 
     private readonly string _id;
     private readonly TrackSegmentGhost _ghost;
 
-    public CreateTrackSegment(string id, string a, string b, int priority = 0, int speedLimit = 0, string groupId = "", TrackSegment.Style style = TrackSegment.Style.Standard, TrackClass trackClass = TrackClass.Mainline) {
+    public CreateTrackSegment(string id, string a, string b, int priority = 0, int speedLimit = 0, string groupId = "", TrackSegment.Style style = TrackSegment.Style.Standard, TrackClass trackClass = TrackClass.Mainline)
+    {
       _id = id;
       _ghost = new TrackSegmentGhost(id, a, b, priority, speedLimit, groupId, style, trackClass);
     }
 
-    public void Apply() {
+    public void Apply()
+    {
       _ghost.CreateSegment();
     }
 
-    public void Revert() {
+    public void Revert()
+    {
       _ghost.DestroySegment();
     }
 
-    public override string ToString() {
+    public override string ToString()
+    {
       return "CreateTrackSegment: " + _id;
     }
 

--- a/MapEditor/StateTracker/Segment/CreateTrackSegment.cs
+++ b/MapEditor/StateTracker/Segment/CreateTrackSegment.cs
@@ -1,0 +1,28 @@
+namespace MapEditor.StateTracker.Segment {
+  using JetBrains.Annotations;
+  using Track;
+
+  public sealed class CreateTrackSegment : IUndoable {
+
+    private readonly string _id;
+    private readonly TrackSegmentGhost _ghost;
+
+    public CreateTrackSegment(string id, string a, string b, int priority = 0, int speedLimit = 0, string groupId = "", TrackSegment.Style style = TrackSegment.Style.Standard, TrackClass trackClass = TrackClass.Mainline) {
+      _id = id;
+      _ghost = new TrackSegmentGhost(id, a, b, priority, speedLimit, groupId, style, trackClass);
+    }
+
+    public void Apply() {
+      _ghost.CreateSegment();
+    }
+
+    public void Revert() {
+      _ghost.DestroySegment();
+    }
+
+    public override string ToString() {
+      return "CreateTrackSegment: " + _id;
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Segment/DeleteTrackSegment.cs
+++ b/MapEditor/StateTracker/Segment/DeleteTrackSegment.cs
@@ -1,25 +1,31 @@
-namespace MapEditor.StateTracker.Segment {
-  using Track;
+using Track;
 
-  public sealed class DeleteTrackSegment : IUndoable {
+namespace MapEditor.StateTracker.Segment
+{
+  public sealed class DeleteTrackSegment : IUndoable
+  {
 
     private readonly string _id;
     private TrackSegmentGhost? _ghost;
 
-    public DeleteTrackSegment(TrackSegment trackSegment) {
+    public DeleteTrackSegment(TrackSegment trackSegment)
+    {
       _id = trackSegment.id!;
     }
 
-    public void Apply() {
+    public void Apply()
+    {
       _ghost = new TrackSegmentGhost(_id);
       _ghost.DestroySegment();
     }
 
-    public void Revert() {
+    public void Revert()
+    {
       _ghost!.CreateSegment();
     }
 
-    public override string ToString() {
+    public override string ToString()
+    {
       return "DeleteTrackNode: " + _id;
     }
 

--- a/MapEditor/StateTracker/Segment/DeleteTrackSegment.cs
+++ b/MapEditor/StateTracker/Segment/DeleteTrackSegment.cs
@@ -1,0 +1,27 @@
+namespace MapEditor.StateTracker.Segment {
+  using Track;
+
+  public sealed class DeleteTrackSegment : IUndoable {
+
+    private readonly string _id;
+    private TrackSegmentGhost? _ghost;
+
+    public DeleteTrackSegment(TrackSegment trackSegment) {
+      _id = trackSegment.id!;
+    }
+
+    public void Apply() {
+      _ghost = new TrackSegmentGhost(_id);
+      _ghost.DestroySegment();
+    }
+
+    public void Revert() {
+      _ghost!.CreateSegment();
+    }
+
+    public override string ToString() {
+      return "DeleteTrackNode: " + _id;
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Segment/TrackSegmentGhost.cs
+++ b/MapEditor/StateTracker/Segment/TrackSegmentGhost.cs
@@ -1,0 +1,72 @@
+namespace MapEditor.StateTracker.Segment {
+  using JetBrains.Annotations;
+  using MapEditor.Extensions;
+  using Track;
+  using UnityEngine;
+
+  public sealed class TrackSegmentGhost {
+
+    private readonly string _id;
+    
+    private string _a;
+    private string _b;
+    private int _priority;
+    private int _speedLimit;
+    private string _groupId;
+    private TrackSegment.Style _style;
+    private TrackClass _trackClass;
+
+    public TrackSegmentGhost(string id) {
+      _id = id;
+    }
+
+    public TrackSegmentGhost(string id, string a, string b, int priority = 0, int speedLimit = 0, string groupId = "", TrackSegment.Style style = TrackSegment.Style.Standard, TrackClass trackClass = TrackClass.Mainline)
+      : this(id) {
+      _a = a;
+      _b = b;
+      _priority = priority;
+      _speedLimit = speedLimit;
+      _groupId = groupId;
+      _style = style;
+      _trackClass = trackClass;
+    }
+
+    public void UpdateGhost(TrackSegment segment) {
+      _a = segment.a.id;
+      _b = segment.b.id;
+      _priority = segment.priority;
+      _speedLimit = segment.speedLimit;
+      _groupId = segment.groupId;
+      _style = segment.style;
+      _trackClass = segment.trackClass;
+    }
+
+    public void UpdateSegment(TrackSegment segment) {
+      segment.a = Graph.Shared.GetNode(_a);
+      segment.b = Graph.Shared.GetNode(_b);
+      segment.priority = _priority;
+      segment.speedLimit = _speedLimit;
+      segment.groupId = _groupId;
+      segment.style = _style;
+      segment.trackClass = _trackClass;
+    }
+
+    public void CreateSegment() {
+      var segment = new GameObject($"Segment {_id}").AddComponent<TrackSegment>();
+      segment.id = _id;
+      segment.transform.SetParent(Graph.Shared.transform);
+      UpdateSegment(segment);
+      Graph.Shared.AddSegment(segment);
+      EditorContext.Instance.PatchEditor.AddOrUpdateSegment(segment);
+    }
+
+    public void DestroySegment() {
+      var segment = Graph.Shared.GetSegment(_id);
+      UpdateGhost(segment);
+      Object.Destroy(segment.gameObject);
+      Graph.Shared.RebuildCollections();
+      EditorContext.Instance.PatchEditor.RemoveSegment(_id);
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Segment/TrackSegmentGhost.cs
+++ b/MapEditor/StateTracker/Segment/TrackSegmentGhost.cs
@@ -1,27 +1,30 @@
-namespace MapEditor.StateTracker.Segment {
-  using JetBrains.Annotations;
-  using MapEditor.Extensions;
-  using Track;
-  using UnityEngine;
+using MapEditor.Extensions;
+using Track;
+using UnityEngine;
 
-  public sealed class TrackSegmentGhost {
+namespace MapEditor.StateTracker.Segment
+{
+  public sealed class TrackSegmentGhost
+  {
 
     private readonly string _id;
-    
+
     private string _a;
     private string _b;
-    private int _priority;
-    private int _speedLimit;
-    private string _groupId;
-    private TrackSegment.Style _style;
-    private TrackClass _trackClass;
+    internal int _priority;
+    internal int _speedLimit;
+    internal string _groupId;
+    internal TrackSegment.Style _style;
+    internal TrackClass _trackClass;
 
-    public TrackSegmentGhost(string id) {
+    public TrackSegmentGhost(string id)
+    {
       _id = id;
     }
 
     public TrackSegmentGhost(string id, string a, string b, int priority = 0, int speedLimit = 0, string groupId = "", TrackSegment.Style style = TrackSegment.Style.Standard, TrackClass trackClass = TrackClass.Mainline)
-      : this(id) {
+      : this(id)
+    {
       _a = a;
       _b = b;
       _priority = priority;
@@ -31,7 +34,8 @@ namespace MapEditor.StateTracker.Segment {
       _trackClass = trackClass;
     }
 
-    public void UpdateGhost(TrackSegment segment) {
+    public void UpdateGhost(TrackSegment segment)
+    {
       _a = segment.a.id;
       _b = segment.b.id;
       _priority = segment.priority;
@@ -41,7 +45,8 @@ namespace MapEditor.StateTracker.Segment {
       _trackClass = segment.trackClass;
     }
 
-    public void UpdateSegment(TrackSegment segment) {
+    public void UpdateSegment(TrackSegment segment)
+    {
       segment.a = Graph.Shared.GetNode(_a);
       segment.b = Graph.Shared.GetNode(_b);
       segment.priority = _priority;
@@ -51,7 +56,8 @@ namespace MapEditor.StateTracker.Segment {
       segment.trackClass = _trackClass;
     }
 
-    public void CreateSegment() {
+    public void CreateSegment()
+    {
       var segment = new GameObject($"Segment {_id}").AddComponent<TrackSegment>();
       segment.id = _id;
       segment.transform.SetParent(Graph.Shared.transform);
@@ -60,7 +66,8 @@ namespace MapEditor.StateTracker.Segment {
       EditorContext.Instance.PatchEditor.AddOrUpdateSegment(segment);
     }
 
-    public void DestroySegment() {
+    public void DestroySegment()
+    {
       var segment = Graph.Shared.GetSegment(_id);
       UpdateGhost(segment);
       Object.Destroy(segment.gameObject);

--- a/MapEditor/StateTracker/TrackNodeChanged.cs
+++ b/MapEditor/StateTracker/TrackNodeChanged.cs
@@ -1,11 +1,13 @@
-using System.Runtime.Remoting.Contexts;
+using System;
 using Track;
 using UnityEngine;
 
 namespace MapEditor.StateTracker
 {
+  [Obsolete("Replaced by as ChangeTrackNode")]
   public class TrackNodeChanged : IUndoable
   {
+
     private readonly TrackNode _node;
     private readonly Vector3 _oldPosition;
     private readonly Vector3 _newPosition;
@@ -42,5 +44,6 @@ namespace MapEditor.StateTracker
       EditorContext.Instance.PatchEditor.AddOrUpdateNode(_node.id, _oldPosition, _oldRotation, _oldFlipSwitchStand);
       Graph.Shared.OnNodeDidChange(_node);
     }
+
   }
 }

--- a/MapEditor/StateTracker/TrackNodeCreated.cs
+++ b/MapEditor/StateTracker/TrackNodeCreated.cs
@@ -1,16 +1,17 @@
-using System.Runtime.Remoting.Contexts;
-using Helpers;
+using System;
 using Track;
 using UnityEngine;
 
 namespace MapEditor.StateTracker
 {
+  [Obsolete("Replaced by as CreateTrackNode")]
   public class TrackNodeCreated : IUndoable
   {
+
     private TrackNode _node;
-    private string _id;
-    private Vector3 _position;
-    private Vector3 _rotation;
+    private readonly string _id;
+    private readonly Vector3 _position;
+    private readonly Vector3 _rotation;
     private bool _flipSwitchStand;
 
     public TrackNodeCreated(string id, Vector3 position, Vector3 rotation, bool flipSwitchStand = false)
@@ -31,7 +32,7 @@ namespace MapEditor.StateTracker
       newNode.flipSwitchStand = false;
       Graph.Shared.AddNode(newNode);
       _node = newNode;
-      EditorContext.Instance.PatchEditor.AddOrUpdateNode(_node.id, _position, _rotation, false);
+      EditorContext.Instance.PatchEditor.AddOrUpdateNode(_node.id, _position, _rotation);
     }
 
     public void Revert()
@@ -40,5 +41,6 @@ namespace MapEditor.StateTracker
       Graph.Shared.RebuildCollections();
       EditorContext.Instance.PatchEditor.RemoveNode(_id);
     }
+
   }
 }

--- a/MapEditor/StateTracker/TrackNodeDeleted.cs
+++ b/MapEditor/StateTracker/TrackNodeDeleted.cs
@@ -1,12 +1,12 @@
-using System.Runtime.Remoting.Contexts;
-using Helpers;
-using Track;
+using System;
 using UnityEngine;
 
 namespace MapEditor.StateTracker
 {
+  [Obsolete("Replaced by as DeleteTrackNode")]
   public class TrackNodeDeleted : TrackNodeCreated
   {
+
     public TrackNodeDeleted(string id, Vector3 position, Vector3 rotation, bool flipSwitchStand) : base(id, position, rotation, flipSwitchStand)
     {
     }
@@ -20,5 +20,6 @@ namespace MapEditor.StateTracker
     {
       base.Apply();
     }
+
   }
 }

--- a/MapEditor/StateTracker/TrackSegmentCreated.cs
+++ b/MapEditor/StateTracker/TrackSegmentCreated.cs
@@ -1,17 +1,19 @@
-using Helpers;
+using System;
 using Track;
 using UnityEngine;
 
 namespace MapEditor.StateTracker
 {
+  [Obsolete("Replaced by as CreateTrackSegment")]
   public class TrackSegmentCreated : IUndoable
   {
+
     private TrackSegment _segment;
-    private string _id;
-    private TrackNode _a;
-    private TrackNode _b;
-    private TrackSegment.Style _style;
-    private string _groupId;
+    private readonly string _id;
+    private readonly TrackNode _a;
+    private readonly TrackNode _b;
+    private readonly TrackSegment.Style _style;
+    private readonly string _groupId;
 
     public TrackSegmentCreated(string id, TrackNode a, TrackNode b, TrackSegment.Style style = TrackSegment.Style.Standard, string groupId = "")
     {
@@ -42,5 +44,6 @@ namespace MapEditor.StateTracker
       Graph.Shared.RebuildCollections();
       EditorContext.Instance.PatchEditor.RemoveSegment(_id);
     }
+
   }
 }

--- a/MapEditor/StateTracker/TrackSegmentDeleted.cs
+++ b/MapEditor/StateTracker/TrackSegmentDeleted.cs
@@ -1,11 +1,12 @@
-using Helpers;
+using System;
 using Track;
-using UnityEngine;
 
 namespace MapEditor.StateTracker
 {
+  [Obsolete("Replaced by as DeleteTrackSegment")]
   public class TrackSegmentDeleted : TrackSegmentCreated
   {
+
     public TrackSegmentDeleted(string id, TrackNode a, TrackNode b, TrackSegment.Style style = TrackSegment.Style.Standard, string groupId = "") : base(id, a, b, style, groupId)
     {
     }
@@ -19,5 +20,6 @@ namespace MapEditor.StateTracker
     {
       base.Apply();
     }
+
   }
 }

--- a/MapEditor/StateTracker/Transform/MoveTransform.cs
+++ b/MapEditor/StateTracker/Transform/MoveTransform.cs
@@ -1,0 +1,26 @@
+namespace MapEditor.StateTracker.Transform {
+  using JetBrains.Annotations;
+  using UnityEngine;
+
+  public sealed class MoveTransform : IUndoable {
+
+    private readonly Transform _transform;
+    private readonly Vector3 _oldPosition;
+    private readonly Vector3 _newPosition;
+
+    public MoveTransform(Transform transform, Vector3 newPosition) {
+      _transform = transform;
+      _oldPosition = transform.localPosition;
+      _newPosition = newPosition;
+    }
+
+    public void Apply() {
+      _transform.localPosition = _newPosition;
+    }
+
+    public void Revert() {
+      _transform.localPosition = _oldPosition;
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/Transform/RotateTransform.cs
+++ b/MapEditor/StateTracker/Transform/RotateTransform.cs
@@ -1,0 +1,26 @@
+namespace MapEditor.StateTracker.Transform {
+  using JetBrains.Annotations;
+  using UnityEngine;
+
+  public sealed class RotateTransform : IUndoable {
+
+    private readonly Transform _transform;
+    private readonly Quaternion _oldRotation;
+    private readonly Quaternion _newRotation;
+
+    public RotateTransform(Transform transform, Quaternion newRotation) {
+      _transform = transform;
+      _oldRotation = transform.localRotation;
+      _newRotation = newRotation;
+    }
+
+    public void Apply() {
+      _transform.localRotation = _newRotation;
+    }
+
+    public void Revert() {
+      _transform.localRotation = _oldRotation;
+    }
+
+  }
+}

--- a/MapEditor/StateTracker/TransformMoved.cs
+++ b/MapEditor/StateTracker/TransformMoved.cs
@@ -1,28 +1,32 @@
+using System;
 using UnityEngine;
 
 namespace MapEditor.StateTracker
 {
-    public class TransformMoved : IUndoable
+  [Obsolete("Replaced by as MoveTransform")]
+  public class TransformMoved : IUndoable
+  {
+
+    private readonly UnityEngine.Transform _transform;
+    private readonly Vector3 _oldPosition;
+    private readonly Vector3 _newPosition;
+
+    public TransformMoved(UnityEngine.Transform transform, Vector3 newPosition)
     {
-        private readonly Transform _transform;
-        private readonly Vector3 _oldPosition;
-        private readonly Vector3 _newPosition;
-
-        public TransformMoved(Transform transform, Vector3 newPosition)
-        {
-            _transform = transform;
-            _oldPosition = transform.localPosition;
-            _newPosition = newPosition;
-        }
-
-        public void Apply()
-        {
-            _transform.localPosition = _newPosition;
-        }
-
-        public void Revert()
-        {
-            _transform.localPosition = _oldPosition;
-        }
+      _transform = transform;
+      _oldPosition = transform.localPosition;
+      _newPosition = newPosition;
     }
+
+    public void Apply()
+    {
+      _transform.localPosition = _newPosition;
+    }
+
+    public void Revert()
+    {
+      _transform.localPosition = _oldPosition;
+    }
+
+  }
 }

--- a/MapEditor/StateTracker/TransformRotated.cs
+++ b/MapEditor/StateTracker/TransformRotated.cs
@@ -1,28 +1,32 @@
+using System;
 using UnityEngine;
 
 namespace MapEditor.StateTracker
 {
-    public class TransformRotated : IUndoable
+  [Obsolete("Replaced by as RotateTransform")]
+  public class TransformRotated : IUndoable
+  {
+
+    private readonly UnityEngine.Transform _transform;
+    private readonly Quaternion _oldRotation;
+    private readonly Quaternion _newRotation;
+
+    public TransformRotated(UnityEngine.Transform transform, Quaternion newRotation)
     {
-        private readonly Transform _transform;
-        private readonly Quaternion _oldRotation;
-        private readonly Quaternion _newRotation;
-
-        public TransformRotated(Transform transform, Quaternion newRotation)
-        {
-            _transform = transform;
-            _oldRotation = transform.localRotation;
-            _newRotation = newRotation;
-        }
-
-        public void Apply()
-        {
-            _transform.localRotation = _newRotation;
-        }
-
-        public void Revert()
-        {
-            _transform.localRotation = _oldRotation;
-        }
+      _transform = transform;
+      _oldRotation = transform.localRotation;
+      _newRotation = newRotation;
     }
+
+    public void Apply()
+    {
+      _transform.localRotation = _newRotation;
+    }
+
+    public void Revert()
+    {
+      _transform.localRotation = _oldRotation;
+    }
+
+  }
 }

--- a/MapEditor/Tools/Tool.cs
+++ b/MapEditor/Tools/Tool.cs
@@ -1,5 +1,6 @@
 namespace MapEditor.Tools {
   public static class Tool {
     public static UIMoveTool UIMoveTool = new UIMoveTool();
+    public static SelectTool SelectTool = new SelectTool();
   } 
 }

--- a/MapEditor/Tools/UIMoveTool.cs
+++ b/MapEditor/Tools/UIMoveTool.cs
@@ -1,192 +1,131 @@
-using System;
-using System.Linq;
-using HarmonyLib;
-using MapEditor.Extensions;
-using MapEditor.StateTracker;
-using Track;
-using UI.Builder;
-using UI.Common;
-using UnityEngine;
-using UnityEngine.UI;
+namespace MapEditor.Tools {
+  using MapEditor.Extensions;
+  using MapEditor.Managers;
+  using MapEditor.StateTracker.Segment;
+  using Track;
+  using UI.Builder;
+  using UI.Common;
+  using UnityEngine;
+  using Resources = MapEditor.Resources;
 
-namespace MapEditor.Tools
-{
-  public class UIMoveTool : BaseTool
-  {
+  public class UIMoveTool : BaseTool {
+
     protected override string ToolIconPath => "Icons/MoveTool";
     protected override string ToolName => "Move";
     protected override string ToolDescription => "Move objects";
 
-    private TrackNode PreviousNode { get; set; }
+    private TrackNode? PreviousNode { get; set; }
 
-    private Window Window { get; set; }
+    public Window Window { get; }
 
-    private float scaling = 1.0f;
-
-    public UIMoveTool()
-    {
-      Window = EditorMod.Shared.UIHelper.CreateWindow(400, 200, UI.Common.Window.Position.CenterRight);
-      EditorMod.Shared.UIHelper.PopulateWindow(Window, builder => BuildWindow(builder));
-      Window.OnShownDidChange += (shown) =>
-      {
-        if (!shown && Context.ActiveTool == this)
-        {
+    public UIMoveTool() {
+      Window = EditorMod.Shared.UIHelper.CreateWindow(400, 300, Window.Position.CenterRight);
+      EditorMod.Shared.UIHelper.PopulateWindow(Window, BuildWindow);
+      Window.OnShownDidChange += shown => {
+        if (!shown && Context.ActiveTool == this) {
           Deactivate();
         }
       };
     }
 
-    private void BuildWindow(UIPanelBuilder builder)
-    {
-      var rotate = (Vector3 offset) =>
-      {
-        var node = Context.SelectedNode;
-        Context.ChangeManager.AddChange(new TrackNodeChanged(node, node.transform.localPosition, node.transform.localEulerAngles + offset, node.flipSwitchStand));
-      };
-
-      var move = (Vector3 offset) =>
-      {
-        var node = Context.SelectedNode;
-        Context.ChangeManager.AddChange(new TrackNodeChanged(node, node.transform.localPosition + offset, node.transform.localEulerAngles, node.flipSwitchStand));
-      };
-
-      var flipSwitchStand = () =>
-      {
-        var node = Context.SelectedNode;
-        Context.ChangeManager.AddChange(new TrackNodeChanged(node, node.transform.localPosition, node.transform.localEulerAngles, !node.flipSwitchStand));
-      };
-
+    private void BuildWindow(UIPanelBuilder builder) {
+      builder.AddField("Keyboard mode", () => KeyboardManager.Rotate ? "rotate" : "move", UIPanelBuilder.Frequency.Periodic);
       builder.AddField("Position", () => Context?.SelectedNode?.transform.localPosition.ToString() ?? "", UIPanelBuilder.Frequency.Periodic);
       builder.AddField("Rotation", () => Context?.SelectedNode?.transform.localEulerAngles.ToString() ?? "", UIPanelBuilder.Frequency.Periodic);
       builder.Spacer();
-      builder.HStack(builder =>
-      {
-        builder.AddSection("Position", builder =>
-        {
-          var arrowUp = Sprite.Create(Resources.Icons.ArrowUp, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f));
-          builder.HStack(builder =>
-          {
-            builder.AddButtonCompact(() => $"- {scaling:F2}", () => move(Context.SelectedNode.transform.up * -scaling));
-            var up = builder.AddIconButton(arrowUp, () => move(Context.SelectedNode.transform.forward * scaling));
-            builder.AddButtonCompact(() => $"+ {scaling:F2}", () => move(Context.SelectedNode.transform.up * scaling));
-          });
-          builder.HStack(builder =>
-          {
-            var left = builder.AddIconButton(arrowUp, () => move(Context.SelectedNode.transform.right * -scaling));
-            left.localEulerAngles += new Vector3(0, 0, 90);
-            var down = builder.AddIconButton(arrowUp, () => move(Context.SelectedNode.transform.forward * -scaling));
-            down.localEulerAngles += new Vector3(0, 0, 180);
-            var right = builder.AddIconButton(arrowUp, () => move(Context.SelectedNode.transform.right * scaling));
-            right.localEulerAngles += new Vector3(0, 0, -90);
-          });
-        });
-        builder.Spacer();
-        builder.AddSection("Rotation", builder =>
-        {
-          var xpos = Sprite.Create(Resources.Icons.RotateAxisX, new Rect(0, 256, 256, -256), new Vector2(0.5f, 0.5f));
-          var xneg = Sprite.Create(Resources.Icons.RotateAxisX, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f));
-          var ypos = Sprite.Create(Resources.Icons.RotateAxisY, new Rect(256, 0, -256, 256), new Vector2(0.5f, 0.5f));
-          var yneg = Sprite.Create(Resources.Icons.RotateAxisY, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f));
-          var zpos = Sprite.Create(Resources.Icons.RotateAxisZ, new Rect(256, 0, -256, 256), new Vector2(0.5f, 0.5f));
-          var zneg = Sprite.Create(Resources.Icons.RotateAxisZ, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f));
-          builder.HStack(builder =>
-          {
-            builder.AddIconButton(zneg, () => rotate(Vector3.forward * -scaling));
-            builder.AddIconButton(xpos, () => rotate(Vector3.right * scaling));
-            builder.AddIconButton(zpos, () => rotate(Vector3.forward * scaling));
-          });
-          builder.HStack(builder =>
-          {
-            builder.AddIconButton(yneg, () => rotate(Vector3.up * -scaling));
-            builder.AddIconButton(xneg, () => rotate(Vector3.right * -scaling));
-            builder.AddIconButton(ypos, () => rotate(Vector3.up * scaling));
-          });
-        });
+      builder.HStack(stack => {
+        stack.AddSection("Position", BuildPositionEditor);
+        stack.Spacer();
+        stack.AddSection("Rotation", BuildRotationEditor);
       });
-      builder.AddSection("Scaling", builder =>
-      {
-        builder.HStack(builder =>
-        {
-          builder.AddButtonCompact("10", () => scaling = 10.0f);
-          builder.AddButtonCompact("5", () => scaling = 5.0f);
-          builder.AddButtonCompact("1", () => scaling = 1.0f);
-          builder.AddButtonCompact("0.5", () => scaling = 0.5f);
-          builder.AddButtonCompact("0.1", () => scaling = 0.1f);
-          builder.AddButtonCompact("0.01", () => scaling = 0.01f);
-        });
-      });
+      builder.AddSection("Scaling", BuildScalingEditor);
 
-      builder.HStack(builder =>
-      {
-        builder.AddButtonCompact("Flip Switch Stand", () => flipSwitchStand());
-        builder.AddButtonCompact("Add Node", () =>
-        {
-          var node = Context.SelectedNode;
-          var nid = Context.TrackNodeIdGenerator.Next();
-          var sid = Context.TrackSegmentIdGenerator.Next();
-          var nodeCreated = new TrackNodeCreated(nid, node.transform.localPosition + (node.transform.forward * scaling), node.transform.localEulerAngles);
-          Context.ChangeManager.AddChange(nodeCreated);
-          var newNode = Graph.Shared.GetNode(nid);
-          var segmentCreated = new TrackSegmentCreated(sid, node, newNode);
-          Context.ChangeManager.AddChange(segmentCreated);
-          // var compoundChange = new CompoundChange(nodeCreated, segmentCreated);
-          // Context.ChangeManager.AddChange(compoundChange);
-          TrackObjectManager.Instance.Rebuild();
-          Context.SelectNode(newNode);
-        });
-        // builder.AddButtonCompact("Delete Node", () =>
-        // {
-        //   var node = Context.SelectedNode;
-        //   if (node == null)
-        //   {
-        //     return;
-        //   }
-        //   var segments = Graph.Shared.SegmentsConnectedTo(node).ToArray();
-        //   foreach (var segment in segments)
-        //   {
-        //     Context.ChangeManager.AddChange(new TrackSegmentDeleted(segment.id, segment.a, segment.b, segment.style, segment.groupId));
-        //   }
-        //   var nodeDeleted = new TrackNodeDeleted(node.id, node.transform.localPosition, node.transform.localEulerAngles, node.flipSwitchStand);
-        //   Context.ChangeManager.AddChange(nodeDeleted);
-        //   EditorContext.Instance.SelectNode(null);
-        //   TrackObjectManager.Instance.Rebuild();
-        // });
+      builder.HStack(BuildNodeEditor);
+    }
+
+    private void BuildPositionEditor(UIPanelBuilder builder) {
+      var arrowUp = Sprite.Create(Resources.Icons.ArrowUp, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f))!;
+      builder.HStack(stack => {
+        stack.AddButtonCompact(() => $"- {NodeManager.Scaling:F2}", () => NodeManager.Move(Direction.down));
+        stack.AddIconButton(arrowUp, () => NodeManager.Move(Direction.forward));
+        stack.AddButtonCompact(() => $"+ {NodeManager.Scaling:F2}", () => NodeManager.Move(Direction.up));
+      });
+      builder.HStack(stack => {
+        var left = stack.AddIconButton(arrowUp, () => NodeManager.Move(Direction.left));
+        left.localEulerAngles += new Vector3(0, 0, 90);
+        var down = stack.AddIconButton(arrowUp, () => NodeManager.Move(Direction.backward));
+        down.localEulerAngles += new Vector3(0, 0, 180);
+        var right = stack.AddIconButton(arrowUp, () => NodeManager.Move(Direction.right));
+        right.localEulerAngles += new Vector3(0, 0, -90);
       });
     }
 
-    private void SelectedNodeChanged(TrackNode node)
-    {
-      if (node == null)
-      {
+    private void BuildRotationEditor(UIPanelBuilder builder) {
+      var xpos = Sprite.Create(Resources.Icons.RotateAxisX, new Rect(0, 256, 256, -256), new Vector2(0.5f, 0.5f))!;
+      var xneg = Sprite.Create(Resources.Icons.RotateAxisX, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f))!;
+      var ypos = Sprite.Create(Resources.Icons.RotateAxisY, new Rect(256, 0, -256, 256), new Vector2(0.5f, 0.5f))!;
+      var yneg = Sprite.Create(Resources.Icons.RotateAxisY, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f))!;
+      var zpos = Sprite.Create(Resources.Icons.RotateAxisZ, new Rect(256, 0, -256, 256), new Vector2(0.5f, 0.5f))!;
+      var zneg = Sprite.Create(Resources.Icons.RotateAxisZ, new Rect(0, 0, 256, 256), new Vector2(0.5f, 0.5f))!;
+      builder.HStack(stack => {
+        stack.AddIconButton(zneg, () => NodeManager.Rotate(Vector3.back));
+        stack.AddIconButton(xpos, () => NodeManager.Rotate(Vector3.right));
+        stack.AddIconButton(zpos, () => NodeManager.Rotate(Vector3.forward));
+      });
+      builder.HStack(stack => {
+        stack.AddIconButton(yneg, () => NodeManager.Rotate(Vector3.down));
+        stack.AddIconButton(xneg, () => NodeManager.Rotate(Vector3.left));
+        stack.AddIconButton(ypos, () => NodeManager.Rotate(Vector3.up));
+      });
+    }
+
+    private void BuildScalingEditor(UIPanelBuilder builder) {
+      builder.HStack(stack => {
+        stack.AddButtonCompact(() => $"+{NodeManager.Scaling:0.##}", NodeManager.IncrementScaling);
+        stack.AddButtonCompact(() => "0", NodeManager.ResetScaling);
+        stack.AddButtonCompact(() => $"-{NodeManager.Scaling:0.##}", NodeManager.DecrementScaling);
+        stack.Spacer();
+        stack.AddButtonCompact(() => "*10", NodeManager.MultiplyScalingDelta);
+        stack.AddLabel(() => $"{NodeManager.ScalingDelta:0.##}", UIPanelBuilder.Frequency.Periodic);
+        stack.AddButtonCompact(() => "/10", NodeManager.DivideScalingDelta);
+      });
+    }
+
+    private void BuildNodeEditor(UIPanelBuilder builder) {
+      builder.AddButtonCompact("Flip", NodeManager.FlipSwitchStand);
+      builder.AddButtonCompact("Add", NodeManager.AddNode);
+      builder.AddButtonCompact("Split", NodeManager.SplitNode);
+      builder.AddButtonCompact("Remove", () => NodeManager.RemoveNode(Input.GetKey(KeyCode.LeftShift)));
+    }
+
+    private void SelectedNodeChanged(TrackNode? node) {
+      if (node == null) {
         Window.CloseWindow();
         return;
       }
+
       Window.Title = $"Node Editor - {node.id}";
-      if (Window.IsShown == false)
-      {
+      if (Window.IsShown == false) {
         Window.ShowWindow();
       }
-      if (Input.GetKey(KeyCode.LeftShift) && PreviousNode != null)
-      {
-        var sid = Context.TrackSegmentIdGenerator.Next();
-        var segmentCreated = new TrackSegmentCreated(sid, PreviousNode, node);
-        Context.ChangeManager.AddChange(segmentCreated);
-        TrackObjectManager.Instance.Rebuild();
+
+      if (Input.GetKey(KeyCode.LeftShift) && PreviousNode != null) {
+        NodeManager.ConnectNodes(PreviousNode.id!);
       }
+
       PreviousNode = node;
     }
 
-    public override void OnActivated()
-    {
+    public override void OnActivated() {
       SelectedNodeChanged(Context.SelectedNode);
       EditorContext.NodeSelectedChanged += SelectedNodeChanged;
     }
 
-    protected override void OnDeactivating()
-    {
+    protected override void OnDeactivating() {
       Window.CloseWindow();
-      EditorContext.NodeSelectedChanged -= SelectedNodeChanged;
+      // NOTE: im unable to reopen window if this is not commented out
+      //EditorContext.NodeSelectedChanged -= SelectedNodeChanged;
     }
-  }
 
+  }
 }

--- a/MapEditor/Tools/UIMoveTool.cs
+++ b/MapEditor/Tools/UIMoveTool.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UI.CompanyWindow;
+
 namespace MapEditor.Tools {
   using MapEditor.Extensions;
   using MapEditor.Managers;
@@ -39,8 +44,7 @@ namespace MapEditor.Tools {
         stack.AddSection("Rotation", BuildRotationEditor);
       });
       builder.AddSection("Scaling", BuildScalingEditor);
-
-      builder.HStack(BuildNodeEditor);
+      builder.AddSection("Nodes", BuildNodeEditor);
     }
 
     private void BuildPositionEditor(UIPanelBuilder builder) {
@@ -81,21 +85,47 @@ namespace MapEditor.Tools {
 
     private void BuildScalingEditor(UIPanelBuilder builder) {
       builder.HStack(stack => {
-        stack.AddButtonCompact(() => $"+{NodeManager.Scaling:0.##}", NodeManager.IncrementScaling);
+        stack.AddButtonCompact(() => $"+{NodeManager.ScalingDelta:0.##}", NodeManager.IncrementScaling);
         stack.AddButtonCompact(() => "0", NodeManager.ResetScaling);
-        stack.AddButtonCompact(() => $"-{NodeManager.Scaling:0.##}", NodeManager.DecrementScaling);
+        stack.AddButtonCompact(() => $"-{NodeManager.ScalingDelta:0.##}", NodeManager.DecrementScaling);
         stack.Spacer();
-        stack.AddButtonCompact(() => "*10", NodeManager.MultiplyScalingDelta);
-        stack.AddLabel(() => $"{NodeManager.ScalingDelta:0.##}", UIPanelBuilder.Frequency.Periodic);
-        stack.AddButtonCompact(() => "/10", NodeManager.DivideScalingDelta);
+        stack.AddButtonCompact(() => "0.01", () => NodeManager.ScalingDelta = 0.01f);
+        stack.AddButtonCompact(() => "0.1", () => NodeManager.ScalingDelta = 0.1f);
+        stack.AddButtonCompact(() => "1", () => NodeManager.ScalingDelta = 1f);
+        stack.AddButtonCompact(() => "10", () => NodeManager.ScalingDelta = 10f);
       });
     }
 
-    private void BuildNodeEditor(UIPanelBuilder builder) {
-      builder.AddButtonCompact("Flip", NodeManager.FlipSwitchStand);
-      builder.AddButtonCompact("Add", NodeManager.AddNode);
-      builder.AddButtonCompact("Split", NodeManager.SplitNode);
-      builder.AddButtonCompact("Remove", () => NodeManager.RemoveNode(Input.GetKey(KeyCode.LeftShift)));
+    private static readonly List<string> NodeMenu = [
+      "More ...",
+      "Copy rotation",
+      "Paste rotation",
+    ];
+
+    private static readonly Action[] NodeMenuActions = [
+      () => {}, 
+      NodeManager.CopyNodeRotation,
+      NodeManager.PasteNodeRotation,
+    ];
+
+    private void BuildNodeEditor(UIPanelBuilder builder)
+    {
+      builder.HStack(stack => {
+        stack.AddButtonCompact("Flip", NodeManager.FlipSwitchStand);
+        stack.AddButtonCompact("Add", NodeManager.AddNode);
+        stack.AddButtonCompact("Split", NodeManager.SplitNode);
+        stack.AddButtonCompact("Remove", () => NodeManager.RemoveNode(Input.GetKey(KeyCode.LeftShift)));
+
+        TMP_Dropdown dd = null!;
+        dd = stack.AddDropdown(NodeMenu, 0, o =>
+          {
+            NodeMenuActions[o]();
+            dd.value = 0;
+          })
+          .FlexibleWidth()
+          .GetComponent<TMP_Dropdown>();
+        dd.MultiSelect = false;
+      });
     }
 
     private void SelectedNodeChanged(TrackNode? node) {

--- a/MapEditor/Tools/UIMoveTool.cs
+++ b/MapEditor/Tools/UIMoveTool.cs
@@ -96,16 +96,8 @@ namespace MapEditor.Tools {
       });
     }
 
-    private static readonly List<string> NodeMenu = [
-      "More ...",
-      "Copy rotation",
-      "Paste rotation",
-    ];
-
-    private static readonly Action[] NodeMenuActions = [
-      () => {}, 
-      NodeManager.CopyNodeRotation,
-      NodeManager.PasteNodeRotation,
+    private static readonly List<PopupMenuItem> NodeMenuItems = [
+    
     ];
 
     private void BuildNodeEditor(UIPanelBuilder builder)
@@ -115,16 +107,12 @@ namespace MapEditor.Tools {
         stack.AddButtonCompact("Add", NodeManager.AddNode);
         stack.AddButtonCompact("Split", NodeManager.SplitNode);
         stack.AddButtonCompact("Remove", () => NodeManager.RemoveNode(Input.GetKey(KeyCode.LeftShift)));
-
-        TMP_Dropdown dd = null!;
-        dd = stack.AddDropdown(NodeMenu, 0, o =>
-          {
-            NodeMenuActions[o]();
-            dd.value = 0;
-          })
-          .FlexibleWidth()
-          .GetComponent<TMP_Dropdown>();
-        dd.MultiSelect = false;
+        stack.AddPopupMenu(
+          new PopupMenuItem("Copy rotation", NodeManager.CopyNodeRotation),
+          new PopupMenuItem("Paste rotation", NodeManager.PasteNodeRotation),
+          new PopupMenuItem("Copy elevation", NodeManager.CopyNodeElevation),
+          new PopupMenuItem("Paste elevation", NodeManager.PasteNodeElevation)
+        );
       });
     }
 

--- a/MapEditor/TrackNodeHelper.cs
+++ b/MapEditor/TrackNodeHelper.cs
@@ -84,6 +84,8 @@ namespace MapEditor
         Destroy(this);
         return;
       }
+
+      LineRenderer.material.color = EditorContext.Instance?.SelectedNode == Node ? Color.magenta : Color.cyan;
       LineRenderer.enabled = EditorMod.Shared.Settings.ShowHelpers;
 
       if (!EditorMod.Shared.IsEnabled)


### PR DESCRIPTION
- selected node chevron is rendered with magenta color
- changed how scale works
   - instead of fixed values (20,10,5,2,1,0.1,0.01) im using +-delta value (so i can have any scale value that i want, also less buttons)
- keyboard support for node editing
    - numpad keys 4,5,6,7,8,9 correspons to ui move / rotate buttons
    - numpad enter toggles between move / rotate operation
    - numpad + and numpad - changes scale
    - numpad * and numpad / changes scale delta
    - numpad 0 resets scale to 0
- refactored code that is editing node from UIMoveTool to NodeManager class
- refactored UIMoveTool BuildWindow method
- refactored StateTracker classes
    - glost classes store info about deleted node/segment for undo/redo magic to work
    - it will also not store those values in ctor, because they may change before Apply/Revert is called

- added 'Split' action to node editor
    - this will remove selected node and replace it with multiple nodes roughly at the same location with track segments 
      connections from old node 'other' nodes
- added 'Remove' action to node editor
    - this will remove node and its segmetnts
    - alt mode for simple rail: removing 'noce B' from (node A --- node B --- node C) will result in (node A --- node C)




issues:
- when I quit to main menu with editor open and start new game editor is still active and also start throwing exception, because some game objects where destryoed
  - tryied to register OnMapDidUnload event but didnt removed editor correctly ...
- when I close UIMoveTool im unable to open it again
  - i 'fixed' that by not removing node changed event handler in OnDeactivating
- game sometimes do not redraw rails correctly ('Rebuild Track' usually fixes that)
  - i think that rebuild is not calling something / its timing issue