### PR TITLE
Feat: Add branch support to PaxStations and Timetable

### DIFF
--- a/AlinasMapMod/Utils.cs
+++ b/AlinasMapMod/Utils.cs
@@ -72,8 +72,7 @@ public class Utils
     if (!prefabUri.Contains("://"))
       throw new ValidationException($"Invalid prefab URI: {prefabUri}, must match the pattern of (empty|path|scenery|vanilla)://host/path");
     var scheme = prefabUri.Split(':')[0];
-    var hostPath = prefabUri.Split(':')[1];
-    var host = hostPath.Split('/')[0];
+    var host = prefabUri.Substring(prefabUri.IndexOf("://") + 3);
     if (scheme == "vanilla" && !vanillaValidList.Contains(host))
       throw new ValidationException($"Invalid vanilla prefab: {host}, must be one of {string.Join(", ", vanillaValidList)}");
   }

--- a/AlinasMapMod/docs/paxstations.md
+++ b/AlinasMapMod/docs/paxstations.md
@@ -1,5 +1,7 @@
 # Pax stations
 
+This allows creating custom stations:
+
 Industry:
 ```json
 {
@@ -20,7 +22,7 @@ Industry:
             "trackSpans": [ // Spans for loading/unloading
               "PAN_Test_Mod_00"
             ],
-            // Future support for custom branches, currently supported is "Main" and "Alarka Branch"
+            // Which branch this stations belongs to:
             "branch": "Main",
             // List of ids of other passenger stations.
             // Unsure of exact impact
@@ -34,3 +36,16 @@ Industry:
   }
 }
 ```
+
+## Branches
+
+A station can be in multiple branches at the same time. E.g. Alarka Jct is in the Main branch and the Alarka branch.
+
+You can specifiy this by separating branche names with a ':':
+```json
+"branch": "Main:My Custom Branch"
+```
+
+This will create a custom branch called "My Custom Branch" that connects to the Main branch at this station.
+
+


### PR DESCRIPTION
Add branches support for the timetable to PaxStations:

<img width="1273" height="295" alt="grafik" src="https://github.com/user-attachments/assets/30777ea3-d09c-4e95-a3cf-91687e98e0ce" />

I added a logic to modify and change existing entries in Timetables and allow that a PaxStation to be in multiple Branches. This is the way Alarka Jct is integrated in the Alarka branch.

Overwriting an existing station is easy:
```json
{
  "areas": {
    "topton": {
      "industries": {
        "topton-station": {
          "name": "Topton Station",
          "usesContract": false,
          "components": {
            "topton": {
              "name": "Topton Station",
              "type": "AlinasMapMod.PaxStationComponent",
              "trackSpans":  [
                "P4jr", "Pbhw"
              ],
              "neighborIds": [],
              "timetableCode": "TO",
              "basePopulation": 15,
              "loadId": "passengers",
              "branch": "Main:Graham County Railroad",
              "carTypeFilter": "*",
              "sharedStorage": true
            }
          }
        }
      }
    }
}
```

I improved some logging and displayed the error message in the validation in the logs too. I didn't see them in the console.

Also I fixed ordering of new stations in the Timetable by sorting them based on the area index/order.

Also fixed a bug in the Utils.cs class for validation of the uris.